### PR TITLE
MVVM Refactoring

### DIFF
--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		2A0E0E752DE6D96F00E4FE1E /* FeedRefreshViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0E0E742DE6D96F00E4FE1E /* FeedRefreshViewController.swift */; };
 		2A42CD052DF163E700F12E7D /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A42CD042DF163E700F12E7D /* FeedImageCellController.swift */; };
 		2A42CD082DF169DC00F12E7D /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A42CD072DF169DC00F12E7D /* FeedUIComposer.swift */; };
+		2A68B2222DF4A2D6008A8D7A /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */; };
 		2A70B06A2DC1E920005CAD4B /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 080EDEF121B6DA7E00813479 /* EssentialFeed.framework */; };
 		2A70B0722DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A70B0702DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift */; };
 		2A88FFE02DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A88FFDF2DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */; };
@@ -146,6 +147,7 @@
 		2A0E0E742DE6D96F00E4FE1E /* FeedRefreshViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRefreshViewController.swift; sourceTree = "<group>"; };
 		2A42CD042DF163E700F12E7D /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		2A42CD072DF169DC00F12E7D /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
+		2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
 		2A70B0662DC1E920005CAD4B /* EssentialFeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A70B0702DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedCacheIntegrationTests.swift; sourceTree = "<group>"; };
 		2A88FFDF2DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 		2A0E0E6F2DE6D74200E4FE1E /* Feed UI */ = {
 			isa = PBXGroup;
 			children = (
+				2A68B2202DF4A2C9008A8D7A /* Models */,
 				2A42CD062DF169CC00F12E7D /* Composers */,
 				2A0E0E652DE6D39200E4FE1E /* Views */,
 				2A0E0E642DE6D38800E4FE1E /* Controllers */,
@@ -375,6 +378,14 @@
 				2A42CD072DF169DC00F12E7D /* FeedUIComposer.swift */,
 			);
 			path = Composers;
+			sourceTree = "<group>";
+		};
+		2A68B2202DF4A2C9008A8D7A /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 		2A70B0712DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests */ = {
@@ -817,6 +828,7 @@
 				2AF346292DDA004A00FEBFFC /* FeedViewController.swift in Sources */,
 				2AE7C01B2DDDD5FC00B82550 /* FeedImageCell.swift in Sources */,
 				2A42CD052DF163E700F12E7D /* FeedImageCellController.swift in Sources */,
+				2A68B2222DF4A2D6008A8D7A /* FeedViewModel.swift in Sources */,
 				2A42CD082DF169DC00F12E7D /* FeedUIComposer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/EssentialFeed.xcodeproj/project.pbxproj
+++ b/EssentialFeed.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		2A42CD052DF163E700F12E7D /* FeedImageCellController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A42CD042DF163E700F12E7D /* FeedImageCellController.swift */; };
 		2A42CD082DF169DC00F12E7D /* FeedUIComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A42CD072DF169DC00F12E7D /* FeedUIComposer.swift */; };
 		2A68B2222DF4A2D6008A8D7A /* FeedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */; };
+		2A68B2242DF4A9EA008A8D7A /* FeedImageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A68B2232DF4A9EA008A8D7A /* FeedImageViewModel.swift */; };
 		2A70B06A2DC1E920005CAD4B /* EssentialFeed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 080EDEF121B6DA7E00813479 /* EssentialFeed.framework */; };
 		2A70B0722DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A70B0702DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift */; };
 		2A88FFE02DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A88FFDF2DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */; };
@@ -148,6 +149,7 @@
 		2A42CD042DF163E700F12E7D /* FeedImageCellController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageCellController.swift; sourceTree = "<group>"; };
 		2A42CD072DF169DC00F12E7D /* FeedUIComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedUIComposer.swift; sourceTree = "<group>"; };
 		2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModel.swift; sourceTree = "<group>"; };
+		2A68B2232DF4A9EA008A8D7A /* FeedImageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageViewModel.swift; sourceTree = "<group>"; };
 		2A70B0662DC1E920005CAD4B /* EssentialFeedCacheIntegrationTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = EssentialFeedCacheIntegrationTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A70B0702DC1EAC0005CAD4B /* EssentialFeedCacheIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialFeedCacheIntegrationTests.swift; sourceTree = "<group>"; };
 		2A88FFDF2DB28EFF00854850 /* XCTestCase+FailableRetrieveFeedStoreSpecs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+FailableRetrieveFeedStoreSpecs.swift"; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 			isa = PBXGroup;
 			children = (
 				2A68B2212DF4A2D6008A8D7A /* FeedViewModel.swift */,
+				2A68B2232DF4A9EA008A8D7A /* FeedImageViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -827,6 +830,7 @@
 				2A8CEED32DDF509700E609C9 /* UIView+Shimmering.swift in Sources */,
 				2AF346292DDA004A00FEBFFC /* FeedViewController.swift in Sources */,
 				2AE7C01B2DDDD5FC00B82550 /* FeedImageCell.swift in Sources */,
+				2A68B2242DF4A9EA008A8D7A /* FeedImageViewModel.swift in Sources */,
 				2A42CD052DF163E700F12E7D /* FeedImageCellController.swift in Sources */,
 				2A68B2222DF4A2D6008A8D7A /* FeedViewModel.swift in Sources */,
 				2A42CD082DF169DC00F12E7D /* FeedUIComposer.swift in Sources */,

--- a/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -13,9 +13,10 @@ public final class FeedUIComposer {
     private init() {}
 
     public static func feedComposedWith(feedLoader: FeedLoader, imageLoader: FeedImageDataLoader) -> FeedViewController {
-        let refreshController = FeedRefreshViewController(feedLoader: feedLoader)
+        let feedViewModel = FeedViewModel(feedLoader: feedLoader)
+        let refreshController = FeedRefreshViewController(viewModel: feedViewModel)
         let feedController = FeedViewController(refreshController: refreshController)
-        refreshController.onRefresh = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
+        feedViewModel.onFeedLoad = adaptFeedToCellControllers(forwardingTo: feedController, loader: imageLoader)
         return feedController
     }
     

--- a/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -23,7 +23,7 @@ public final class FeedUIComposer {
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         { [weak controller] feed in
             controller?.tableModel = feed.map { model in
-                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader))
+                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader, imageTransformer: UIImage.init))
             }
         }
     }

--- a/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
+++ b/EssentialFeediOS/Feed UI/Composers/FeedUIComposer.swift
@@ -23,7 +23,7 @@ public final class FeedUIComposer {
     private static func adaptFeedToCellControllers(forwardingTo controller: FeedViewController, loader: FeedImageDataLoader) -> ([FeedImage]) -> Void {
         { [weak controller] feed in
             controller?.tableModel = feed.map { model in
-                FeedImageCellController(model: model, imageLoader: loader)
+                FeedImageCellController(viewModel: FeedImageViewModel(model: model, imageLoader: loader))
             }
         }
     }

--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -10,9 +10,9 @@ import EssentialFeed
 
 final class FeedImageCellController {
     
-    private let viewModel: FeedImageViewModel
+    private let viewModel: FeedImageViewModel<UIImage>
     
-    init(viewModel: FeedImageViewModel) {
+    init(viewModel: FeedImageViewModel<UIImage>) {
         self.viewModel = viewModel
     }
     

--- a/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedImageCellController.swift
@@ -10,48 +10,45 @@ import EssentialFeed
 
 final class FeedImageCellController {
     
-    private var task: FeedImageDataLoaderTask?
-    private let model: FeedImage
-    private let imageLoader: FeedImageDataLoader
+    private let viewModel: FeedImageViewModel
     
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
-        self.model = model
-        self.imageLoader = imageLoader
+    init(viewModel: FeedImageViewModel) {
+        self.viewModel = viewModel
     }
     
     func view() -> UITableViewCell {
-        
-        let cell = FeedImageCell()
-        cell.locationContainer.isHidden = (model.location == nil)
-        cell.locationLabel.text = model.location
-        cell.descriptionLabel.text = model.description
-        cell.feedImageView.image = nil
-        cell.feedImageRetryButton.isHidden = true
-        cell.feedImageContainer.isShimmering = true
-        
-        let loadImage = { [weak self, weak cell] in
-            
-            guard let self else { return }
-            
-            self.task = self.imageLoader.loadImageData(from: self.model.url) { [weak cell] result in
-                let data = try? result.get()
-                let image = data.map(UIImage.init) ?? nil
-                cell?.feedImageView.image = image
-                cell?.feedImageRetryButton.isHidden = (image != nil)
-                cell?.feedImageContainer.isShimmering = false
-            }
-        }
-        cell.onRetry = loadImage
-        loadImage()
-        
+        let cell = binded(FeedImageCell())
+        viewModel.loadImageData()
         return cell
     }
     
     func preload() {
-        task = imageLoader.loadImageData(from: model.url) { _ in }
+        viewModel.loadImageData()
     }
     
     func cancelLoad() {
-        task?.cancel()
+        viewModel.cancelImageDataLoad()
+    }
+    
+    private func binded(_ cell: FeedImageCell) -> FeedImageCell {
+        
+        cell.locationContainer.isHidden = !viewModel.hasLocation
+        cell.locationLabel.text = viewModel.location
+        cell.descriptionLabel.text = viewModel.description
+        cell.onRetry = viewModel.loadImageData
+        
+        viewModel.onImageLoad = { [weak cell] image in
+            cell?.feedImageView.image = image
+        }
+        
+        viewModel.onImageLoadingStateChange = { [weak cell] isLoading in
+            cell?.feedImageContainer.isShimmering = isLoading
+        }
+        
+        viewModel.onShouldRetryImageLoadStateChange = { [weak cell] shouldRetry in
+            cell?.feedImageRetryButton.isHidden = !shouldRetry
+        }
+        
+        return cell
     }
 }

--- a/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -23,8 +23,8 @@ public final class FeedRefreshViewController: NSObject {
     }
     
     private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
-        viewModel.onChange = { [weak self] viewModel in
-            if viewModel.isLoading {
+        viewModel.onLoadingStateChange = { [weak self] isLoading in
+            if isLoading {
                 self?.view.beginRefreshing()
             } else {
                 self?.view.endRefreshing()

--- a/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedRefreshViewController.swift
@@ -10,29 +10,27 @@ import EssentialFeed
 
 public final class FeedRefreshViewController: NSObject {
     
-    public lazy var view: UIRefreshControl = {
-        let view = UIRefreshControl()
-        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
-        return view
-    }()
+    public lazy var view = binded(UIRefreshControl())
 
-    private let feedLoader: FeedLoader
+    private let viewModel: FeedViewModel
 
-    init(feedLoader: FeedLoader) {
-        self.feedLoader = feedLoader
+    init(viewModel: FeedViewModel) {
+        self.viewModel = viewModel
     }
 
-    var onRefresh: (([FeedImage]) -> Void)?
-
     @objc func refresh() {
-        
-        view.beginRefreshing()
-        
-        feedLoader.load { [weak self] result in
-            if let feed = try? result.get() {
-                self?.onRefresh?(feed)
+        viewModel.loadFeed()
+    }
+    
+    private func binded(_ view: UIRefreshControl) -> UIRefreshControl {
+        viewModel.onChange = { [weak self] viewModel in
+            if viewModel.isLoading {
+                self?.view.beginRefreshing()
+            } else {
+                self?.view.endRefreshing()
             }
-            self?.view.endRefreshing()
         }
+        view.addTarget(self, action: #selector(refresh), for: .valueChanged)
+        return view
     }
 }

--- a/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Christos Tzimas on 18/5/25.
 //
 
-import EssentialFeed
 import UIKit
 
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching {

--- a/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -6,20 +6,21 @@
 //
 
 import Foundation
-import UIKit
 import EssentialFeed
 
-final class FeedImageViewModel {
+final class FeedImageViewModel<Image> {
     
     typealias Observer<T> = (T) -> Void
 
     private var task: FeedImageDataLoaderTask?
     private let model: FeedImage
     private let imageLoader: FeedImageDataLoader
+    private let imageTransformer: (Data) -> Image?
 
-    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+    init(model: FeedImage, imageLoader: FeedImageDataLoader, imageTransformer: @escaping (Data) -> Image?) {
         self.model = model
         self.imageLoader = imageLoader
+        self.imageTransformer = imageTransformer
     }
 
     var description: String? {
@@ -34,7 +35,7 @@ final class FeedImageViewModel {
         location != nil
     }
 
-    var onImageLoad: Observer<UIImage>?
+    var onImageLoad: Observer<Image>?
     var onImageLoadingStateChange: Observer<Bool>?
     var onShouldRetryImageLoadStateChange: Observer<Bool>?
 
@@ -47,7 +48,7 @@ final class FeedImageViewModel {
     }
 
     private func handle(_ result: FeedImageDataLoader.Result) {
-        if let image = (try? result.get()).flatMap(UIImage.init) {
+        if let image = (try? result.get()).flatMap(imageTransformer) {
             onImageLoad?(image)
         } else {
             onShouldRetryImageLoadStateChange?(true)

--- a/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
+++ b/EssentialFeediOS/Feed UI/Models/FeedImageViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  FeedImageViewModel.swift
+//  EssentialFeediOS
+//
+//  Created by Christos Tzimas on 7/6/25.
+//
+
+import Foundation
+import UIKit
+import EssentialFeed
+
+final class FeedImageViewModel {
+    
+    typealias Observer<T> = (T) -> Void
+
+    private var task: FeedImageDataLoaderTask?
+    private let model: FeedImage
+    private let imageLoader: FeedImageDataLoader
+
+    init(model: FeedImage, imageLoader: FeedImageDataLoader) {
+        self.model = model
+        self.imageLoader = imageLoader
+    }
+
+    var description: String? {
+        model.description
+    }
+
+    var location: String?  {
+        model.location
+    }
+
+    var hasLocation: Bool {
+        location != nil
+    }
+
+    var onImageLoad: Observer<UIImage>?
+    var onImageLoadingStateChange: Observer<Bool>?
+    var onShouldRetryImageLoadStateChange: Observer<Bool>?
+
+    func loadImageData() {
+        onImageLoadingStateChange?(true)
+        onShouldRetryImageLoadStateChange?(false)
+        task = imageLoader.loadImageData(from: model.url) { [weak self] result in
+            self?.handle(result)
+        }
+    }
+
+    private func handle(_ result: FeedImageDataLoader.Result) {
+        if let image = (try? result.get()).flatMap(UIImage.init) {
+            onImageLoad?(image)
+        } else {
+            onShouldRetryImageLoadStateChange?(true)
+        }
+        onImageLoadingStateChange?(false)
+    }
+
+    func cancelImageDataLoad() {
+        task?.cancel()
+        task = nil
+    }
+}

--- a/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  FeedViewModel.swift
+//  EssentialFeediOS
+//
+//  Created by Christos Tzimas on 7/6/25.
+//
+
+import Foundation
+import EssentialFeed
+
+final class FeedViewModel {
+    
+    private let feedLoader: FeedLoader
+
+    init(feedLoader: FeedLoader) {
+        self.feedLoader = feedLoader
+    }
+
+    var onChange: ((FeedViewModel) -> Void)?
+    var onFeedLoad: (([FeedImage]) -> Void)?
+
+    private(set) var isLoading: Bool = false {
+        didSet { onChange?(self) }
+    }
+
+    func loadFeed() {
+        isLoading = true
+        feedLoader.load { [weak self] result in
+            if let feed = try? result.get() {
+                self?.onFeedLoad?(feed)
+            }
+            self?.isLoading = false
+        }
+    }
+}

--- a/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
+++ b/EssentialFeediOS/Feed UI/Models/FeedViewModel.swift
@@ -10,26 +10,24 @@ import EssentialFeed
 
 final class FeedViewModel {
     
+    typealias Observer<T> = (T) -> Void
+    
     private let feedLoader: FeedLoader
 
     init(feedLoader: FeedLoader) {
         self.feedLoader = feedLoader
     }
 
-    var onChange: ((FeedViewModel) -> Void)?
-    var onFeedLoad: (([FeedImage]) -> Void)?
-
-    private(set) var isLoading: Bool = false {
-        didSet { onChange?(self) }
-    }
+    var onLoadingStateChange: Observer<Bool>?
+    var onFeedLoad: Observer<[FeedImage]>?
 
     func loadFeed() {
-        isLoading = true
+        onLoadingStateChange?(true)
         feedLoader.load { [weak self] result in
             if let feed = try? result.get() {
                 self?.onFeedLoad?(feed)
             }
-            self?.isLoading = false
+            self?.onLoadingStateChange?(false)
         }
     }
 }


### PR DESCRIPTION
Moved model state management from `UIKit` View Controllers (UI layer) into cross-platform View Models (Presentation layer).

View Controllers now act as Binders between the View and the View Model.

The UI+Presentation composition happens within the `FeedUIComposer`.